### PR TITLE
pass extra url parameters for showBuildLogs.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This is source code for new [CMSSDT IB page](https://cmssdt.cern.ch/SDT/html/cmssdt-ib). It must be transpiled before deploying.
 
-## To start
+## To start local development
 ```sh
-cd public && ./updateData.sh && cd ..
-npm install
-npm run start
+docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app -p 3000:3000  node:8 bash  # starts NPM in docker enviroment
+cd public && ./updateData.sh && cd ..  # populate enviroment with latest testing data 
+npm install  # install dependencies
+npm run start  # run development server
 ```

--- a/src/Components/IBPageComponents/ComparisonTable.js
+++ b/src/Components/IBPageComponents/ComparisonTable.js
@@ -147,7 +147,7 @@ class ComparisonTable extends Component {
     }
 
     renderRowCellsWithDefaultPreConfig({resultType, getUrl, showLabelConfig, urlParameter=''}) {
-        const showGeneralResults = this.showGeneralResults(showLabelConfig, getUrl);
+        const showGeneralResults = this.showGeneralResults(showLabelConfig, getUrl, urlParameter);
         const config = {
             resultType: resultType,
             ifPassed: function (details, ib) {
@@ -237,7 +237,7 @@ class ComparisonTable extends Component {
         };
     }
 
-    showGeneralResults(showLabelConfig, getUrl) {
+    showGeneralResults(showLabelConfig, getUrl, urlParameter) {
         return function (result, ib) {
             const {details, done} = result;
             const resultKeys = Object.keys(details); //get all object properties name
@@ -272,7 +272,7 @@ class ComparisonTable extends Component {
             return renderCell(renderLabel(
                 {
                     colorType: labelConfig.colorType, value: labelConfig.value, tooltipContent,
-                    link: getUrl({"file": result.file, "arch": result.arch, "ibName": ib})
+                    link: getUrl({"file": result.file, "arch": result.arch, "ibName": ib, "urlParameter": urlParameter })
                 })
             );
 
@@ -315,9 +315,8 @@ class ComparisonTable extends Component {
 
     shouldShowRow(resultType){
         /**
-         checks if there is at least 1  field to show
+         checks if there is at least 1 field to show
          ibField - the row
-
          */
         const {archsByIb, ibComparison} = this.state;
         let result  =  ibComparison.map((ib, pos) => {
@@ -339,7 +338,8 @@ class ComparisonTable extends Component {
         const {archsByIb} = this.state;
         // TODO refactor and put to configs
         const getBuildOrUnitUrl = function (params) {
-            const {file, arch, ibName, urlParameter} = params;
+            const {file, arch, ibName} = params;
+            const urlParameter = params.urlParameter ? params.urlParameter : '';
             if (!file) {
                 // do nothing
             } else if (file === 'not-ready') {
@@ -480,19 +480,19 @@ class ComparisonTable extends Component {
                         </tr>
                     : null}
                     {  this.shouldShowRow("utests") ?
-                    <tr>
-                        <td className={'name-column'}><b>Unit Tests</b></td>
-                        {this.renderRowCellsWithDefaultPreConfig({
-                                resultType: 'utests',
-                                getUrl: getBuildOrUnitUrl,
-                                showLabelConfig: [{
-                                    groupFields: ["num_fails"],
-                                    color: "danger"
-                                }],
-                                urlParameter: '?utests'
-                            }
-                        )}
-                    </tr>
+                        <tr>
+                            <td className={'name-column'}><b>Unit Tests</b></td>
+                            {this.renderRowCellsWithDefaultPreConfig({
+                                    resultType: 'utests',
+                                    getUrl: getBuildOrUnitUrl,
+                                    showLabelConfig: [{
+                                        groupFields: ["num_fails"],
+                                        color: "danger"
+                                    }],
+                                    urlParameter: '?utests'
+                                }
+                            )}
+                        </tr>
                     : null}
                     {  this.shouldShowRow("gpu_utests") ?
                         <tr>

--- a/src/Components/IBPageComponents/ComparisonTable.js
+++ b/src/Components/IBPageComponents/ComparisonTable.js
@@ -146,7 +146,7 @@ class ComparisonTable extends Component {
         })
     }
 
-    renderRowCellsWithDefaultPreConfig({resultType, getUrl, showLabelConfig}) {
+    renderRowCellsWithDefaultPreConfig({resultType, getUrl, showLabelConfig, urlParameter=''}) {
         const showGeneralResults = this.showGeneralResults(showLabelConfig, getUrl);
         const config = {
             resultType: resultType,
@@ -157,7 +157,7 @@ class ComparisonTable extends Component {
                         colorType: 'success',
                         glyphicon: 'glyphicon-ok-circle',
                         tooltipContent,
-                        link: getUrl({"file": details.file, "arch": details.arch, "ibName": ib})
+                        link: getUrl({"file": details.file, "arch": details.arch, "ibName": ib, "urlParameter": urlParameter})
                     }
                 );
                 return renderCell(cellInfo);
@@ -339,7 +339,7 @@ class ComparisonTable extends Component {
         const {archsByIb} = this.state;
         // TODO refactor and put to configs
         const getBuildOrUnitUrl = function (params) {
-            const {file, arch, ibName} = params;
+            const {file, arch, ibName, urlParameter} = params;
             if (!file) {
                 // do nothing
             } else if (file === 'not-ready') {
@@ -348,7 +348,7 @@ class ComparisonTable extends Component {
                 let link_parts = file.split('/');
                 const si = 4;
                 link_parts = link_parts.slice(si, si + 5);
-                return urls.buildOrUnitTestUrl + link_parts.join('/');
+                return urls.buildOrUnitTestUrl + link_parts.join('/') + urlParameter;
             }
         };
 
@@ -474,7 +474,7 @@ class ComparisonTable extends Component {
                                         groupFields: ["compWarning"],
                                         color: "warning"
                                     }
-                                ],
+                                ]
                             }
                         )}
                         </tr>
@@ -488,7 +488,8 @@ class ComparisonTable extends Component {
                                 showLabelConfig: [{
                                     groupFields: ["num_fails"],
                                     color: "danger"
-                                }]
+                                }],
+                                urlParameter: '?utests'
                             }
                         )}
                     </tr>
@@ -502,7 +503,8 @@ class ComparisonTable extends Component {
                                     showLabelConfig: [{
                                         groupFields: ["num_fails"],
                                         color: "danger"
-                                    }]
+                                    }],
+                                    urlParameter: '?gpu_utests'
                                 }
                             )}
                         </tr>


### PR DESCRIPTION
@gudrutis , please check if this looks good. Idea is that when we click on 'Unit Tests' or 'GPU Unit Tests' icon on the main IB page then it should take us to something like

GPU Unit tests:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc700/www/wed/10.5-wed-11/CMSSW_10_5_X_2019-01-09-1100?gpu_utests

Unit Tests:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc700/www/wed/10.5-wed-11/CMSSW_10_5_X_2019-01-09-1100?utests

