### PR TITLE
Add link to IB profiling results

### DIFF
--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -121,6 +121,11 @@ class Navigation extends Component {
                             {olderLinks}
                         </NavDropdown>
                     </Nav>
+   		    <Nav>
+    		        <NavItem href="https://monit-grafana.cern.ch/d/HtKKjajMz/profiling?orgId=11">
+    			    IB Profiling results
+    		        </NavItem>
+    		    </Nav>
                     <Nav pullRight>
                         <OverlayTrigger placement="left" overlay={popoverHelp}>
                             <button className="btn btn-default navbar-btn" onClick={this.handleShow}>

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -122,7 +122,7 @@ class Navigation extends Component {
                         </NavDropdown>
                     </Nav>
    		    <Nav>
-    		        <NavItem href="https://monit-grafana.cern.ch/d/HtKKjajMz/profiling?orgId=11">
+    		        <NavItem href="https://monit-grafana.cern.ch/d/000000530/cms-monitoring-project?viewPanel=60&orgId=11">
     			    IB Profiling results
     		        </NavItem>
     		    </Nav>


### PR DESCRIPTION
This change adds a link "IB Profling links" to the top level navigation bar.

Verified by running Docker image created using directions in README.md and opening the page in Safari. 