### PR TITLE
Add link on the page to the UBSAN logs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -378,6 +378,20 @@ export const config = {
             }}
         },
         {
+            name: "UBSAN runtime errors",
+            key: "ubsan-logs",
+            getUrl: function (ib) {
+                return "https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/" + getCurrentIbTag(ib);
+            },
+            ifError: function(ib, result) {
+                return {
+                    name: this.name,
+                    glyphicon: "glyphicon-remove",
+                    url:  this.getUrl(ib),
+                    labelColor: "red"
+            }}
+        },
+        {
             name: "FWLite",
             key: "fwlite",
             getUrl: function (ib) {


### PR DESCRIPTION
this is to add the link on the page following previous examples from Zygimantas
and to complete https://github.com/cms-sw/cms-bot/pull/1637