### PR TITLE
[fix]:added scroll for mobile filter

### DIFF
--- a/src/Components/RelValComponents/RelValNavigation.js
+++ b/src/Components/RelValComponents/RelValNavigation.js
@@ -238,7 +238,7 @@ const RelValNavigation = ({
 
             {/* FILTERS AREA */}
             <div
-              className="w-100"
+              className={`w-100 relval-filters-container ${showFilters ? "show" : ""}`}
               style={{
                 maxHeight: showFilters ? "1000px" : "0",
                 overflow: "hidden",
@@ -528,6 +528,15 @@ const RelValNavigation = ({
       </Modal>
 
       <style>{`
+        @media (max-width: 768px) {
+          .relval-filters-container.show {
+            max-height: calc(100dvh - 170px - env(safe-area-inset-bottom)) !important;
+            overflow-y: auto !important;
+            overflow-x: hidden !important;
+            padding-bottom: calc(80px + env(safe-area-inset-bottom)) !important;
+            -webkit-overflow-scrolling: touch;
+          }
+        }
         .legend-modal .modal-content {
           border: none;
           border-radius: 16px;

--- a/src/Components/RelValLayout.js
+++ b/src/Components/RelValLayout.js
@@ -286,7 +286,10 @@ const RelValLayout = () => {
   }, [getNavigationHeight, dataLoaded]);
 
   const getTopPadding = () => navigationHeight + 20;
-  const getSizeForTable = () => document.documentElement.clientHeight - getTopPadding() - 20;
+  const getSizeForTable = () =>
+    (window.visualViewport?.height || document.documentElement.clientHeight)
+    - getTopPadding()
+    - 20;
 
   const resultTableWithStepsSettings = useMemo(() => ({
     style: { height: getSizeForTable(), overflow: 'auto' },


### PR DESCRIPTION
### PR Description
On some mobile devices, the browser UI (address bar and bottom navigation bar) reduces the visible viewport height. As a result, the RelVal filter panel could become partially hidden, making the last filter rows difficult or impossible to access.

This change keeps the desktop behavior unchanged while improving usability on mobile devices.